### PR TITLE
#163025981 add endpoint for resetting password

### DIFF
--- a/api/v1/__init__.py
+++ b/api/v1/__init__.py
@@ -1,6 +1,7 @@
 from flask import Flask
 from v1.auth.sign_up import sign_up
 from v1.auth.log_in import log_in
+from v1.auth.reset import reset
 
 
 def create_app():
@@ -14,5 +15,6 @@ def create_app():
     # register blueprints
     app.register_blueprint(sign_up)
     app.register_blueprint(log_in)
+    app.register_blueprint(reset)
 
     return app

--- a/api/v1/auth/reset.py
+++ b/api/v1/auth/reset.py
@@ -1,0 +1,37 @@
+from flask import request, abort, jsonify, Blueprint
+from v1.auth import models
+import re
+
+reset = Blueprint('reset', __name__, url_prefix='/api/v1/auth')
+
+
+@reset.route('/reset', methods=['POST'])
+def user_reset():
+
+    try:
+        email = request.json['email']
+
+        # check that data is in a correct format
+        if not re.match(r"(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)", email):
+            return jsonify(
+                {
+                    "status": 400,
+                    "error": "email format invalid"
+                }), 400
+        if any(u['email'] == email for u in models.users):
+            return jsonify(
+                {
+                    "status": 200,
+                    "data": [{
+                        "msg": "a reset link has been sent to your email",
+                        "email": email
+                    }]
+                }), 200
+        else:
+            return jsonify(
+                {
+                    "status": 401,
+                    "error": "that account does not exist"
+                }), 401
+    except (ValueError, KeyError, TypeError):
+        abort(400)

--- a/api/v1/tests/test_auth.py
+++ b/api/v1/tests/test_auth.py
@@ -53,3 +53,27 @@ def test_log_in_invalid_password(main):
     }
     res = post_json(main, '/api/v1/auth/login', test_data)
     assert res.status_code == 401
+
+
+def test_reset_valid(main):
+    test_data = {
+        'email': 'kwangonya@gmail.com'
+    }
+    res = post_json(main, '/api/v1/auth/reset', test_data)
+    assert res.status_code == 200
+
+
+def test_reset_invalid_email(main):
+    test_data = {
+        'email': 'kwangonyagmail.com'
+    }
+    res = post_json(main, '/api/v1/auth/reset', test_data)
+    assert res.status_code == 400
+
+
+def test_reset_invalid(main):
+    test_data = {
+        'email': 'kwango@gmail.com'
+    }
+    res = post_json(main, '/api/v1/auth/reset', test_data)
+    assert res.status_code == 401


### PR DESCRIPTION
#### What does this PR do?
Adds the `POST /auth/reset` endpoint

#### Description of Task to be completed?
- [x] Write tests
- [x] Add the `POST /auth/reset` endpoint

#### How should this be manually tested?
* Clone the repo
* Activate venv and run `pip install requirements.txt`
* Run `app.py`

#### Any background context you want to provide?
Database not connected yet

#### What are the relevant pivotal tracker stories?
`#163025981`

#### Screenshots
![screenshot-reset](https://user-images.githubusercontent.com/19375569/50821541-81524d00-1340-11e9-99bf-ba7b3bc92ec6.png)
