### PR TITLE
#163026239 add endpoint for users to view meetups

### DIFF
--- a/api/v1/__init__.py
+++ b/api/v1/__init__.py
@@ -2,6 +2,7 @@ from flask import Flask
 from v1.auth.sign_up import sign_up
 from v1.auth.log_in import log_in
 from v1.auth.reset import reset
+from v1.meetups.view_meetups import upcoming_meetups
 
 
 def create_app():
@@ -16,5 +17,6 @@ def create_app():
     app.register_blueprint(sign_up)
     app.register_blueprint(log_in)
     app.register_blueprint(reset)
+    app.register_blueprint(upcoming_meetups)
 
     return app

--- a/api/v1/meetups/models.py
+++ b/api/v1/meetups/models.py
@@ -1,0 +1,16 @@
+meetups = [
+    {
+        "id": 1,
+        "title": "sample meetup",
+        "location": "test location",
+        "happeningOn": "test date",
+        "tags": ["tag1", "tag2", "tag3"]
+    },
+    {
+        "id": 2,
+        "title": "sample meetup2",
+        "location": "test location2",
+        "happeningOn": "test date2",
+        "tags": ["tag1", "tag2", "tag3"]
+    }
+]

--- a/api/v1/meetups/view_meetups.py
+++ b/api/v1/meetups/view_meetups.py
@@ -1,0 +1,13 @@
+from flask import jsonify, Blueprint
+from v1.meetups import models
+
+upcoming_meetups = Blueprint('upcoming_meetups', __name__, url_prefix='/api/v1/')
+
+
+@upcoming_meetups.route('/meetups/upcoming', methods=['GET'])
+def get_upcoming_meetups():
+    return jsonify(
+        {
+            "status": 200,
+            "data": models.meetups
+        }), 200

--- a/api/v1/tests/test_get_upcoming_meetups.py
+++ b/api/v1/tests/test_get_upcoming_meetups.py
@@ -1,0 +1,6 @@
+from v1.tests import main
+
+
+def test_get_questions(main):
+    res = main.get('/api/v1/meetups/upcoming')
+    assert res.status_code == 200


### PR DESCRIPTION
#### What does this PR do?
Adds the `GET /meetups/upcoming` endpoint

#### Description of Task to be completed?
- [x] Write tests
- [x] Add the `GET /meetups/upcoming` endpoint

#### How should this be manually tested?
* Clone the repo
* Activate venv and run `pip install requirements.txt`
* Run `app.py`
* Use postman/insomnia to access the endpoint `GET /api/v1/meetups/upcoming`

#### Any background context you want to provide?
Database not connected yet

#### What are the relevant pivotal tracker stories?
`#163026239`

#### Screenshots
![screenshot-upcoming](https://user-images.githubusercontent.com/19375569/50832909-ace52f80-1360-11e9-9fb9-cd5dba23020e.png)
