### PR TITLE
#163026393 add endpoint for viewing a specific meetup 

### DIFF
--- a/api/v1/__init__.py
+++ b/api/v1/__init__.py
@@ -2,7 +2,7 @@ from flask import Flask
 from v1.auth.sign_up import sign_up
 from v1.auth.log_in import log_in
 from v1.auth.reset import reset
-from v1.meetups.view_meetups import upcoming_meetups
+from v1.meetups.view_meetups import upcoming_meetups, specific_meetup
 
 
 def create_app():
@@ -18,5 +18,6 @@ def create_app():
     app.register_blueprint(log_in)
     app.register_blueprint(reset)
     app.register_blueprint(upcoming_meetups)
+    app.register_blueprint(specific_meetup)
 
     return app

--- a/api/v1/meetups/view_meetups.py
+++ b/api/v1/meetups/view_meetups.py
@@ -2,6 +2,7 @@ from flask import jsonify, Blueprint
 from v1.meetups import models
 
 upcoming_meetups = Blueprint('upcoming_meetups', __name__, url_prefix='/api/v1/')
+specific_meetup = Blueprint('specific_meetup', __name__, url_prefix='/api/v1/')
 
 
 @upcoming_meetups.route('/meetups/upcoming', methods=['GET'])
@@ -11,3 +12,20 @@ def get_upcoming_meetups():
             "status": 200,
             "data": models.meetups
         }), 200
+
+
+@specific_meetup.route('/meetups/<int:m_id>', methods=['GET'])
+def get_specific_meetup(m_id):
+    meetup = [meetup for meetup in models.meetups if meetup['id'] == m_id]
+    if len(meetup) == 0:
+        return jsonify(
+            {
+                "status": 404,
+                "error": "a meetup with id {} does not exist".format(m_id)
+            }), 404
+    else:
+        return jsonify(
+            {
+                "status": 200,
+                "data": meetup[0]
+            }), 200

--- a/api/v1/tests/test_get_meetups.py
+++ b/api/v1/tests/test_get_meetups.py
@@ -1,0 +1,11 @@
+from v1.tests import main
+
+
+def test_get_upcoming_meetups(main):
+    res = main.get('/api/v1/meetups/upcoming')
+    assert res.status_code == 200
+
+
+def test_specific_meetup(main):
+    res = main.get('/api/v1/meetups/1')
+    assert res.status_code == 200

--- a/api/v1/tests/test_get_upcoming_meetups.py
+++ b/api/v1/tests/test_get_upcoming_meetups.py
@@ -1,6 +1,0 @@
-from v1.tests import main
-
-
-def test_get_questions(main):
-    res = main.get('/api/v1/meetups/upcoming')
-    assert res.status_code == 200


### PR DESCRIPTION
#### What does this PR do?
Adds the `GET /api/v1/meetups/<meetup-id>` endpoint

#### Description of Task to be completed?
- [x] Write tests
- [x] Add the `GET /api/v1/meetups/<meetup-id>` endpoint

#### How should this be manually tested?
* Clone the repo
* Activate venv and run `pip install requirements.txt`
* Run `app.py`
* Use a Rest client to access `GET /api/v1/meetups/<meetup-id>`

#### Any background context you want to provide?
Database not connected yet

#### What are the relevant pivotal tracker stories?
`#163026393`

#### Screenshots
![screenshot-specific-meetup](https://user-images.githubusercontent.com/19375569/50838993-68619000-1370-11e9-918f-f09e6465603c.png)
