### PR TITLE
#163061539 setup flask-jwt-extended

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -2,12 +2,14 @@ atomicwrites==1.2.1
 attrs==18.2.0
 Click==7.0
 Flask==1.0.2
+Flask-JWT-Extended==3.15.0
 itsdangerous==1.1.0
 Jinja2==2.10
 MarkupSafe==1.1.0
 more-itertools==5.0.0
 pluggy==0.8.0
 py==1.7.0
+PyJWT==1.7.1
 pytest==4.1.0
 six==1.12.0
 Werkzeug==0.14.1

--- a/api/v1/__init__.py
+++ b/api/v1/__init__.py
@@ -1,4 +1,5 @@
 from flask import Flask
+from flask_jwt_extended import JWTManager
 from v1.auth.sign_up import sign_up
 from v1.auth.log_in import log_in
 from v1.auth.reset import reset
@@ -8,6 +9,7 @@ from v1.meetups.view_meetups import upcoming_meetups, specific_meetup
 def create_app():
     app = Flask(__name__, instance_relative_config=True)
     app.config.from_pyfile('config.cfg')
+    jwt = JWTManager(app)
 
     @app.route('/')
     def hello():

--- a/api/v1/auth/log_in.py
+++ b/api/v1/auth/log_in.py
@@ -1,5 +1,6 @@
 from flask import request, abort, jsonify, Blueprint
 from werkzeug.security import check_password_hash
+from flask_jwt_extended import create_access_token
 from v1.auth import models
 import re
 
@@ -23,12 +24,14 @@ def user_login():
         if any(u['email'] == email for u in models.users):
             get_user_password = [u['password'] for u in models.users if u['email'] == email]
             if check_password_hash(get_user_password[0], password):
+                access_token = create_access_token(identity=email)
                 return jsonify(
                     {
                         "status": 200,
                         "data": [{
                             "msg": "user logged in successfully",
-                            "email": email
+                            "email": email,
+                            "access_token": access_token
                         }]
                     }), 200
             else:

--- a/api/v1/auth/sign_up.py
+++ b/api/v1/auth/sign_up.py
@@ -1,5 +1,6 @@
 from flask import request, abort, jsonify, Blueprint
 from werkzeug.security import generate_password_hash
+from flask_jwt_extended import create_access_token
 from v1.auth import models
 import re
 import datetime as date
@@ -58,12 +59,14 @@ def user_signup():
                 'isAdmin': isadmin
             }
             models.users.append(user)
+            access_token = create_access_token(identity=email)
             return jsonify(
                 {
                     "status": 201,
                     "data": [{
                         "msg": "user registered successfully",
-                        "user": user
+                        "user": user,
+                        "access_token": access_token
                     }]
                 }), 201
     except (ValueError, KeyError, TypeError):


### PR DESCRIPTION
#### What does this PR do?
Downloads and sets up flask-jwt-extended

#### Description of Task to be completed?
- [x] Download flask-jwt-extended
- [x] Update `/login` and `/signup` to return access tokens on success

#### How should this be manually tested?
* Clone the repo
* Activate venv and run `pip install requirements.txt`
* Run `app.py`

#### Any background context you want to provide?
Returning an access token allows me to identify the user which will make creating endpoints that need user id returned in response easier

#### What are the relevant pivotal tracker stories?
`#163061539`