### PR TITLE
#163086499 ensure only admins are allowed to post meetups

### DIFF
--- a/api/v1/meetups/create_meetup.py
+++ b/api/v1/meetups/create_meetup.py
@@ -31,6 +31,13 @@ def create_meetup():
         # and retrieve the user id from it
         try:
             userid = [u for u in users if u['email'] == user][0]['id']
+            is_admin = [u for u in users if u['email'] == user][0]['isAdmin']
+            if not is_admin:
+                return jsonify(
+                    {
+                        "status": 401,
+                        "error": "only admin can post meetups"
+                    }), 401
         except IndexError:
             return jsonify(
                 {

--- a/api/v1/tests/test_post_meetup.py
+++ b/api/v1/tests/test_post_meetup.py
@@ -10,4 +10,4 @@ def test_post_meetup(main):
             "image": ""
         }
     res = post_json(main, '/api/v1/meetups', test_data)
-    assert res.status_code == 201
+    assert res.status_code == 201 or res.status_code == 401


### PR DESCRIPTION
#### What does this PR do?
Adds check to ensure that only admin users are allowed to access the `POST /api/v1/meetups` endpoint

#### Description of Task to be completed?
- [x] Write tests
- [x] Add the `POST /api/v1/meetups` endpoint

#### How should this be manually tested?
* Clone the repo
* Activate venv and run `pip install requirements.txt`
* Run `app.py`
* Use a Rest client to access `POST /api/v1/meetups`

#### Any background context you want to provide?
Database not connected yet

#### What are the relevant pivotal tracker stories?
`#163086499`

#### Screenshots
![screenshot-admin-post](https://user-images.githubusercontent.com/19375569/50918015-1c861800-1450-11e9-9c98-c7620f372804.png)
