### PR TITLE
#163027929 created endpoint for admin to view their meetups

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -4,7 +4,7 @@ from flask_jwt_extended import JWTManager
 from api.v1.auth.sign_up import sign_up
 from api.v1.auth.log_in import log_in
 from api.v1.auth.reset import reset
-from api.v1.meetups.view_meetups import upcoming_meetups, specific_meetup
+from api.v1.meetups.view_meetups import upcoming_meetups, specific_meetup, admin_meetup
 from api.v1.meetups.create_meetup import create_m
 from api.v1.meetups.rsvp import rsvp_m
 from api.v1.questions.post_questions import post_q
@@ -43,6 +43,7 @@ def create_app(test_config=None):
     app.register_blueprint(reset)
     app.register_blueprint(upcoming_meetups)
     app.register_blueprint(specific_meetup)
+    app.register_blueprint(admin_meetup)
     app.register_blueprint(post_q)
     app.register_blueprint(upvote_q)
     app.register_blueprint(create_m)

--- a/api/v1/tests/test_get_meetups.py
+++ b/api/v1/tests/test_get_meetups.py
@@ -1,11 +1,23 @@
 from api.v1.tests import main
 
 
-def test_get_upcoming_meetups(main):
+def test_get_no_upcoming_meetups(main):
     res = main.get('/api/v1/meetups/upcoming')
     assert res.status_code == 200
+
+
+def test_no_specific_meetup(main):
+    res = main.get('/api/v1/meetups/54')
+    assert res.status_code == 404
 
 
 def test_specific_meetup(main):
     res = main.get('/api/v1/meetups/1')
     assert res.status_code == 200
+
+
+def test_admin_meetup(main):
+    res = main.get('/api/v1/admin/profile/1')
+    assert res.status_code == 200 or res.status_code == 401
+
+


### PR DESCRIPTION
#### What does this PR do?
Adds the `GET /api/v1/admin/profile/<u_id>` endpoint for admins to get the meetups they have created when they access their profiles

#### Description of Task to be completed?
- [x] Write tests
- [x] Add the `GET /api/v1/admin/profile/<u_id>` endpoint

#### How should this be manually tested?
* Clone the repo
* Activate venv and run `pip install requirements.txt`
* Run `run.py`
* Use a Rest client to access `GET /api/v1/admin/profile/<u_id>`

#### Any background context you want to provide?
Database not connected yet

#### What are the relevant pivotal tracker stories?
`#163027929`

#### Screenshots
