### PR TITLE
#163268998 fix bug to check for duplicate rsvp entries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install:
 
 before_script: cd api
 script:
-  - pytest --cov=v1
+  - pytest --cov-config .coveragerc --cov=v1
 
 after_success:
   - coveralls

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # questioner
 [![Build Status](https://travis-ci.org/wangonya/questioner.svg?branch=develop)](https://travis-ci.org/wangonya/questioner)
 [![Coverage Status](https://coveralls.io/repos/github/wangonya/questioner/badge.svg?branch=develop)](https://coveralls.io/github/wangonya/questioner?branch=develop)
+[![Maintainability](https://api.codeclimate.com/v1/badges/d8c9e9b932819c21cee8/maintainability)](https://codeclimate.com/github/wangonya/questioner/maintainability)
 
 Crowd-source questions for a meetup. Questioner helps the meetup organizer prioritize questions to be answered. Other users can vote on asked questions and they bubble to the top or bottom of the log.
 
@@ -13,7 +14,7 @@ Crowd-source questions for a meetup. Questioner helps the meetup organizer prior
 |POST /meetups*   |Create new meetup   |/api/v1/meetups   |
 |GET /meetups/< meetup-id >   |Fetch specific meetup record   |/api/v1/meetups/< meetup-id >   |
 |GET /meetups/upcoming   |Get all upcoming meetups   |/api/v1/meetups/upcoming   |
-|POST /questions   |Post a new question on a meetup   |/api/v1//questions   |
+|POST meetups/< meetup-id >/questions   |Post a new question on a meetup   |/api/v1/meetups/< meetup-id >/questions   |
 |PATCH /questions/< question-id >/upvote   |Upvote a specific question   |/api/v1/questions/< question-id >/upvote   |
 |PATCH /questions/< question-id >/downvote   |Downvote a specific question   |/api/v1/questions/< question-id >/downvote   |
 |POST /meetups/< meetup-id >/rsvps   |Respond to meetup RSVP   |/api/v1/meetups/< meetup-id >/rsvps   |

--- a/api/.coveragerc
+++ b/api/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+omit = */tests/*

--- a/api/v1/meetups/models.py
+++ b/api/v1/meetups/models.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from api.v1.utils.error_handlers import DataIndexError
+from api.v1.utils.error_handlers import DataIndexError, DuplicateDataError
 
 
 class MeetupModel:
@@ -73,3 +73,11 @@ class RsvpsModel:
     def save_rsvp_to_db(self):
         """save entered rsvp data to db"""
         RsvpsModel.rsvps.append(self)
+
+    @classmethod
+    def check_duplicate_rsvp(cls, userid, m_id):
+        """check if user has already rsvp'd
+        if they have, remove the record"""
+        if any(r.uid == userid and r.m_id == m_id for r in cls.rsvps):
+            rsvp_index = [i for i, r in enumerate(cls.rsvps) if r.uid == userid and r.m_id == m_id][0]
+            cls.rsvps.pop(rsvp_index)

--- a/api/v1/meetups/rsvp.py
+++ b/api/v1/meetups/rsvp.py
@@ -13,7 +13,6 @@ class Rsvp(Resource):
                         required=True,
                         help="This field cannot be left blank!")
 
-    # TODO: CHECK FOR AND HANDLE DUPLICATES
     @jwt_required
     def post(self, m_id):
         """do POST on rsvp endpoint"""
@@ -25,6 +24,9 @@ class Rsvp(Resource):
 
         # validate status
         RsvpValidators.check_proper_rsvp(status)
+
+        # check duplicate -- return update if true
+        RsvpsModel.check_duplicate_rsvp(userid, m_id)
 
         rsvp = RsvpsModel(status, userid, m_id)
         rsvp.save_rsvp_to_db()


### PR DESCRIPTION
#### What does this PR do?
Checks if duplicate rsvp entry exists before posing. If it does, it removes it and adds the new one to allow user update the rsvp instead of returning 409 conflict.

#### Description of Task to be completed?
-[x] Add rsvp duplicate check 
-[x] Add coverage rule to skip tests folder

#### How should this be manually tested?
* Clone the repo
* Activate virtualenv venv and run pip3 install requirements.txt
* export FLASK_APP=run.pyRun python3 -m flask run
* Use a Rest client to access `GET /api/v1/admin/profile/<u_id>`

#### Any background context you want to provide?
* Database not connected yet

#### What are the relevant pivotal tracker stories?
PT board [link](https://www.pivotaltracker.com/n/projects/2235158)
`#163268998`